### PR TITLE
chore: update npm deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@defi-wonderland/natspec-smells": "^1.1.5",
-        "@types/node": "^20.0.0",
+        "@types/node": "20.17.10",
         "commander": "^12.1.0",
         "glob": "^11.0.0",
         "husky": "^9.1.7",
         "tsup": "^8.3.5",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
-        "viem": "^2.21.54"
+        "viem": "^2.21.55"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1282,14 +1282,14 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.2.tgz",
-      "integrity": "sha512-0lk0PHFe/uz0vl527fG9CgdE9WdafjDbCXvBbs+LUv000TVt2Jjhqbs4Jwm8gz070w8xXyEAxrPOMullsxXeGg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "get-intrinsic": "^1.2.5"
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1299,9 +1299,9 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.2.tgz",
+      "integrity": "sha512-/b57FK+bblSU+dfewfFe0rT1YjVDfOmeLQwCAuC+vwvgLkXboATqqmy+Ipux6JrF6L5joe5CBnFOw+gLWH6yKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1547,13 +1547,13 @@
       }
     },
     "node_modules/dunder-proto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
-      "integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
         "gopd": "^1.2.0"
       },
@@ -2253,13 +2253,13 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.14.tgz",
+      "integrity": "sha512-lQUsHzcTb7rH57dajbOuZEuMDXjs9f04ZloER4QOpjpKcaw4f98BRUrs8aiO9Z4G7i7B0Xhgarg6SCgYcYi8Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@defi-wonderland/natspec-smells": "^1.1.5",
-    "@types/node": "^20.0.0",
+    "@types/node": "20.17.10",
     "commander": "^12.1.0",
     "glob": "^11.0.0",
     "husky": "^9.1.7",
     "tsup": "^8.3.5",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
-    "viem": "^2.21.54"
+    "viem": "^2.21.55"
   }
 }


### PR DESCRIPTION
This also pins the version of the `@types/node` dep so that dependabot stops trying to update it.